### PR TITLE
feat: get watching/remit/long running tasks async [sc-11199]

### DIFF
--- a/lib/Tymly-sdk.js
+++ b/lib/Tymly-sdk.js
@@ -197,22 +197,20 @@ module.exports = class TymlyClient {
 
     this.info.set('lastUserQueryStart', new Date().toISOString())
 
-    stopwatch.addTime('Get watched boards via state machine')
-    const watching = await this.executions.execute({
-      stateMachineName: 'tymly_getWatchedBoards_1_0',
-      input: {},
-      token
-    })
-
-    stopwatch.addTime('Get user remit via state machine')
-    const remit = await this.executions.execute({
-      stateMachineName: 'tymly_getUserRemit_1_0',
-      input: { clientManifest },
-      token
-    })
-
-    stopwatch.addTime('List long running tasks via state machine')
-    const tasks = await this.tasks.update(token)
+    stopwatch.addTime('Get watched boards, remit, long-running tasks')
+    const [watching, remit, tasks] = await Promise.all([
+      this.executions.execute({
+        stateMachineName: 'tymly_getWatchedBoards_1_0',
+        input: {},
+        token
+      }),
+      this.executions.execute({
+        stateMachineName: 'tymly_getUserRemit_1_0',
+        input: { clientManifest },
+        token
+      }),
+      this.tasks.update(token)
+    ])
 
     this.info.set('lastUserQueryEnd', new Date().toISOString())
 


### PR DESCRIPTION
This is an enhancement to the synchronising process. Getting watched boards/remit/long running tasks can be done simultaneously rather than waiting on each other as the 3 steps do not depend on each other.