### PR TITLE
Avoid excessive browser storage of executions by enforcing a limit

### DIFF
--- a/lib/Executions.js
+++ b/lib/Executions.js
@@ -12,6 +12,16 @@ module.exports = class Executions {
     this.tymlyApiUrl = client.options.tymlyApiUrl
     this._getHash = client._getHash
     this.auth = client.auth
+    this.limit = client.options.executionLimit || 100
+  }
+
+  async storeExecution (exec) {
+    const existing = await this.db.executions.toArray()
+    if (existing.length === this.limit) {
+      const { executionName } = existing.sort((a, b) => new Date(a.localStateDate) - new Date(b.localStateDate))[0]
+      await this.db.executions.delete(executionName)
+    }
+    await this.db.executions.put(exec)
   }
 
   /**
@@ -157,7 +167,7 @@ module.exports = class Executions {
       }
     }
 
-    await this.db.executions.put(res)
+    await this.storeExecution(res)
   }
 
   /**
@@ -197,7 +207,7 @@ module.exports = class Executions {
     execution.localState = status
     execution.localStateDate = new Date()
     execution.requiredHumanInput.data = data
-    await this.db.executions.put(execution)
+    await this.storeExecution(execution)
   }
 
   /**


### PR DESCRIPTION
Story details: https://app.shortcut.com/wmfs/story/11199