### PR TITLE
fix: change adding templates to use bulkPut

### DIFF
--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -57,14 +57,13 @@ module.exports = class Templates {
         })
     )
 
-    await Promise.all(
+    await this.db.templates.bulkPut(
       Object
         .values(cardsToAdd)
         .filter(card => card.type && card.type === 'AdaptiveCard')
         .map(card => {
           const uiName = `${card.namespace}_${card.name}`
-          console.log('Adding template:', uiName)
-          return this.db.templates.put({ uiName, ...card, _modified })
+          return { uiName, ...card, _modified }
         })
     )
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/wmfs/story/11199/investigate-sync-slowness

> If you have a large number of objects to add to the object store, bulkPut() is faster than doing put() in a loop
https://dexie.org/docs/Table/Table.bulkPut()#remarks