### PR TITLE
Make use of bulkPut, bulkDelete instead of put, delete in loops

### DIFF
--- a/lib/Categories.js
+++ b/lib/Categories.js
@@ -16,9 +16,9 @@ module.exports = class Categories {
     const categoriesToRemove = userQuery.remove.categories || []
     const categoriesToAdd = userQuery.add.categories
       ? Object.values(userQuery.add.categories).map(c => {
-        c._modified = _modified
-        return c
-      })
+          c._modified = _modified
+          return c
+        })
       : []
 
     if (categoriesToRemove.length) await this.db.categories.bulkDelete(categoriesToRemove)

--- a/lib/Categories.js
+++ b/lib/Categories.js
@@ -11,10 +11,12 @@ module.exports = class Categories {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
+    const _modified = new Date()
+
     const categoriesToRemove = userQuery.remove.categories || []
     const categoriesToAdd = userQuery.add.categories
       ? Object.values(userQuery.add.categories).map(c => {
-        c._modified = new Date()
+        c._modified = _modified
         return c
       })
       : []

--- a/lib/Categories.js
+++ b/lib/Categories.js
@@ -11,17 +11,16 @@ module.exports = class Categories {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
-    const categoriesToAdd = userQuery.add.categories || {}
     const categoriesToRemove = userQuery.remove.categories || []
-
-    await Promise.all(categoriesToRemove.map(c => this.db.categories.delete(c)))
-
-    await Promise.all(
-      Object.values(categoriesToAdd).map(c => {
+    const categoriesToAdd = userQuery.add.categories
+      ? Object.values(userQuery.add.categories).map(c => {
         c._modified = new Date()
-        return this.db.categories.put(c)
+        return c
       })
-    )
+      : []
+
+    if (categoriesToRemove.length) await this.db.categories.bulkDelete(categoriesToRemove)
+    if (categoriesToAdd.length) await this.db.categories.bulkPut(categoriesToAdd)
 
     console.log(`Persisted categories in ${Date.now() - startTime}ms`)
   }

--- a/lib/Startables.js
+++ b/lib/Startables.js
@@ -18,9 +18,9 @@ module.exports = class Startables {
     const startablesToRemove = userQuery.remove.startable || []
     const startablesToAdd = userQuery.add.startable
       ? Object.values(userQuery.add.startable).map(s => {
-        s._modified = _modified
-        return s
-      })
+          s._modified = _modified
+          return s
+        })
       : []
 
     if (startablesToRemove.length) await this.db.startables.bulkDelete(startablesToRemove)

--- a/lib/Startables.js
+++ b/lib/Startables.js
@@ -13,17 +13,18 @@ module.exports = class Startables {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
-    const startablesToAdd = userQuery.add.startable || {}
+    const _modified = new Date()
+
     const startablesToRemove = userQuery.remove.startable || []
-
-    await Promise.all(startablesToRemove.map(s => this.db.startables.delete(s)))
-
-    await Promise.all(
-      Object.values(startablesToAdd).map(s => {
-        s._modified = new Date()
-        return this.db.startables.put(s)
+    const startablesToAdd = userQuery.add.startable
+      ? Object.values(userQuery.add.startable).map(s => {
+        s._modified = _modified
+        return s
       })
-    )
+      : []
+
+    if (startablesToRemove.length) await this.db.startables.bulkDelete(startablesToRemove)
+    if (startablesToAdd.length) await this.db.startables.bulkPut(startablesToAdd)
 
     const { favouriteStartableNames } = userQuery
     await this.db.favourites.put({ id: 'favourites', favourites: favouriteStartableNames })
@@ -33,8 +34,8 @@ module.exports = class Startables {
 
   /**
    * Load startables from indexedDB to store
-    @example
-      await sdk.startables.load()
+   @example
+   await sdk.startables.load()
    */
   async load () {
     const startables = await this.db.startables.toArray()
@@ -48,8 +49,8 @@ module.exports = class Startables {
   /**
    * Favourite a startable and persist where appropriate
    * @param {String} id ID of startable to mark as favourite
-    @example
-      await sdk.startables.favourite(id)
+   @example
+   await sdk.startables.favourite(id)
    */
   // todo: probably refactor these
   async favourite (id) {
@@ -65,8 +66,8 @@ module.exports = class Startables {
   /**
    * Unfavourite a startable and persist where appropriate
    * @param {String} id ID of startable to remove from favourites
-    @example
-      await sdk.startables.unfavourite(id)
+   @example
+   await sdk.startables.unfavourite(id)
    */
   async unfavourite (id) {
     this.store.commit('app/unfavourite', id)
@@ -83,8 +84,8 @@ module.exports = class Startables {
   /**
    * execute setFavouriteStartableNames state machine to persist favourites state to backend DB
    * @param {Object} favourites Favourites object to persist to the server
-    @example
-      await sdk.startables.updateFavouritesOnServer(favourites)
+   @example
+   await sdk.startables.updateFavouritesOnServer(favourites)
    */
   updateFavouritesOnServer (favourites) {
     return this.executions.execute({

--- a/lib/Tasks.js
+++ b/lib/Tasks.js
@@ -62,14 +62,16 @@ module.exports = class Tasks {
 
     const updateDb = async (array, dbTable) => {
       await dbTable.clear()
-      for (const task of array) {
-        await dbTable.put({
-          executionName: task.executionName,
-          executionTitle: task.title,
-          stateMachineName: task.stateMachineName,
-          startDate: task.created,
-          updateDate: task.modified
-        })
+      if (array.length) {
+        await dbTable.bulkPut(array.map(task => {
+          return {
+            executionName: task.executionName,
+            executionTitle: task.title,
+            stateMachineName: task.stateMachineName,
+            startDate: task.created,
+            updateDate: task.modified
+          }
+        }))
       }
     }
 

--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -42,6 +42,8 @@ module.exports = class Templates {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
+    const _modified = new Date()
+
     const cardsToRemove = userQuery.remove.cards
       ? userQuery.remove.cards
         .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
@@ -58,8 +60,6 @@ module.exports = class Templates {
             return { uiName, ...card, _modified }
           })
       : []
-
-    const _modified = new Date()
 
     if (cardsToRemove.length) await this.db.templates.bulkDelete(cardsToRemove)
     if (cardsToAdd.length) await this.db.templates.bulkPut(cardsToAdd)

--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -42,6 +42,13 @@ module.exports = class Templates {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
+    const cardsToRemove = userQuery.remove.cards
+      ? userQuery.remove.cards
+        .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
+        .filter(template => template)
+        .map(template => template.uiName)
+      : []
+
     const cardsToAdd = userQuery.add.cards
       ? Object
           .values(userQuery.add.cards)
@@ -50,13 +57,6 @@ module.exports = class Templates {
             const uiName = `${card.namespace}_${card.name}`
             return { uiName, ...card, _modified }
           })
-      : []
-
-    const cardsToRemove = userQuery.remove.cards
-      ? userQuery.remove.cards
-          .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
-          .filter(template => template)
-          .map(template => template.uiName)
       : []
 
     const _modified = new Date()

--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -46,9 +46,9 @@ module.exports = class Templates {
 
     const cardsToRemove = userQuery.remove.cards
       ? userQuery.remove.cards
-        .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
-        .filter(template => template)
-        .map(template => template.uiName)
+          .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
+          .filter(template => template)
+          .map(template => template.uiName)
       : []
 
     const cardsToAdd = userQuery.add.cards

--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -42,27 +42,27 @@ module.exports = class Templates {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
-    const cardsToAdd = userQuery.add.cards || {}
-    const cardsToRemove = userQuery.remove.cards || []
+    const cardsToAdd = userQuery.add.cards
+      ? Object
+          .values(userQuery.add.cards)
+          .filter(card => card.type && card.type === 'AdaptiveCard')
+          .map(card => {
+            const uiName = `${card.namespace}_${card.name}`
+            return { uiName, ...card, _modified }
+          })
+      : []
+
+    const cardsToRemove = userQuery.remove.cards
+      ? userQuery.remove.cards
+          .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
+          .filter(template => template)
+          .map(template => template.uiName)
+      : []
 
     const _modified = new Date()
 
-    await this.db.templates.bulkDelete(
-      cardsToRemove
-        .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
-        .filter(template => template)
-        .map(template => template.uiName)
-    )
-
-    await this.db.templates.bulkPut(
-      Object
-        .values(cardsToAdd)
-        .filter(card => card.type && card.type === 'AdaptiveCard')
-        .map(card => {
-          const uiName = `${card.namespace}_${card.name}`
-          return { uiName, ...card, _modified }
-        })
-    )
+    if (cardsToRemove.length) await this.db.templates.bulkDelete(cardsToRemove)
+    if (cardsToAdd.length) await this.db.templates.bulkPut(cardsToAdd)
 
     console.log(`Persisted templates in ${Date.now() - startTime}ms`)
   }

--- a/lib/Templates.js
+++ b/lib/Templates.js
@@ -47,14 +47,11 @@ module.exports = class Templates {
 
     const _modified = new Date()
 
-    await Promise.all(
+    await this.db.templates.bulkDelete(
       cardsToRemove
         .map(card => this.store.state.app.templates.find(t => `${t.namespace}_${t.name}_${t.version.replace(/\./g, '_')}` === card))
         .filter(template => template)
-        .map(template => {
-          console.log('Removing template:', template.uiName)
-          return this.db.templates.delete(template.uiName)
-        })
+        .map(template => template.uiName)
     )
 
     await this.db.templates.bulkPut(

--- a/lib/Todo.js
+++ b/lib/Todo.js
@@ -13,11 +13,11 @@ module.exports = class Todo {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
-    const todosToAdd = userQuery.add.todos || {}
     const todosToRemove = userQuery.remove.todos || []
+    const todosToAdd = userQuery.add.todos ? Object.values(userQuery.add.todos) : {}
 
-    await Promise.all(todosToRemove.map(t => this.db.todo.delete(t)))
-    await Promise.all(Object.values(todosToAdd).map(t => this.db.todo.put(t)))
+    if (todosToRemove.length) await this.db.todo.bulkDelete(todosToRemove)
+    if (todosToAdd.length) await this.db.todo.bulkPut(todosToAdd)
 
     console.log(`Persisted todos in ${Date.now() - startTime}ms`)
   }

--- a/lib/Todo.js
+++ b/lib/Todo.js
@@ -14,7 +14,7 @@ module.exports = class Todo {
     const startTime = Date.now()
 
     const todosToRemove = userQuery.remove.todos || []
-    const todosToAdd = userQuery.add.todos ? Object.values(userQuery.add.todos) : {}
+    const todosToAdd = userQuery.add.todos ? Object.values(userQuery.add.todos) : []
 
     if (todosToRemove.length) await this.db.todo.bulkDelete(todosToRemove)
     if (todosToAdd.length) await this.db.todo.bulkPut(todosToAdd)

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -27,24 +27,7 @@ module.exports = class Watching {
 
     await this.db.watching.clear()
     if (watching.length) await this.db.watching.bulkPut(watching)
-    /*
-        await Promise.all(
-          Object.entries(watching).map(([categoryName, category]) => {
-            const promises = []
-            Object.values(category).forEach(({ subscriptions }) => {
-              subscriptions.forEach(sub => {
-                promises.push(
-                  this.db.watching.put({
-                    ...sub,
-                    category: categoryName
-                  })
-                )
-              })
-            })
-            return promises
-          })
-        )
-    */
+
     // for (const [categoryName, category] of Object.entries(watching)) {
     //   for (const { subscriptions } of Object.values(category)) {
     //     for (const sub of subscriptions) {

--- a/lib/Watching.js
+++ b/lib/Watching.js
@@ -13,26 +13,38 @@ module.exports = class Watching {
   async persistFromUserQuery (userQuery) {
     const startTime = Date.now()
 
-    const { watching } = userQuery
+    const watching = userQuery.watching
+      ? Object.entries(userQuery.watching).reduce((acc, [categoryName, category]) => {
+          Object.values(category).forEach(({ subscriptions }) => {
+            subscriptions.forEach(sub => {
+              acc.push({ ...sub, category: categoryName })
+            })
+          })
+
+          return acc
+        }, [])
+      : []
 
     await this.db.watching.clear()
-
-    await Promise.all(
-      Object.entries(watching).map(([categoryName, category]) => {
-        const promises = []
-        Object.values(category).forEach(({ subscriptions }) => {
-          subscriptions.forEach(sub => {
-            promises.push(
-              this.db.watching.put({
-                ...sub,
-                category: categoryName
+    if (watching.length) await this.db.watching.bulkPut(watching)
+    /*
+        await Promise.all(
+          Object.entries(watching).map(([categoryName, category]) => {
+            const promises = []
+            Object.values(category).forEach(({ subscriptions }) => {
+              subscriptions.forEach(sub => {
+                promises.push(
+                  this.db.watching.put({
+                    ...sub,
+                    category: categoryName
+                  })
+                )
               })
-            )
+            })
+            return promises
           })
-        })
-        return promises
-      })
-    )
+        )
+    */
     // for (const [categoryName, category] of Object.entries(watching)) {
     //   for (const { subscriptions } of Object.values(category)) {
     //     for (const sub of subscriptions) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/wmfs/story/11199

Reason for change:

> If you have a large number of objects to add to the object store, bulkPut() is faster than doing put() in a loop
https://dexie.org/docs/Table/Table.bulkPut()#remarks

This has been implemented for `templates` and proved to be a significant performance improvement so this is to change all current usages of put/delete in loops to use bulkPut and bulkDelete.